### PR TITLE
fix: correct duplicate currency symbol

### DIFF
--- a/src/components/TransactionTable.jsx
+++ b/src/components/TransactionTable.jsx
@@ -43,9 +43,9 @@ function formatAmountEUR(row) {
   const base = Number(row.amount) || 0;
   const isNegative = row.main === 'expense' || row.main === 'debt';
   const abs = Math.abs(base);
-  const num = nice(abs); // es. 1.234,56
+  const num = nice(abs); // es. 1.234,56 €
   const sign = isNegative ? '-' : '+';
-  return `${sign} € ${num}`;
+  return `${sign} ${num}`;
 }
 
 /* Ricava nome e icona sottocategoria da campi vari (compat backend) */


### PR DESCRIPTION
## Summary
- fix duplicate euro symbol in transaction table formatting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a109be4fa4832084744794360a6c77